### PR TITLE
skip interface if no node is connected

### DIFF
--- a/packages/cotonete/files/usr/sbin/cotonete.sh
+++ b/packages/cotonete/files/usr/sbin/cotonete.sh
@@ -64,6 +64,10 @@ function check_and_fix_wifi {
         for iface in `ls /sys/kernel/debug/ieee80211/$phy/ | grep netdev | cut -c 8-`; do
             test_node=`get_best_node_on_iface $iface`
 
+            if [ -z $test_node ]; then
+                continue
+            fi
+
             raw_stations_info=`iwinfo $iface a`
             stations_info=`echo "$raw_stations_info" | filter_MCS_and_Mhz | four_lines_in_one`
             working_station_info=`echo "$stations_info" | grep $test_node`


### PR DESCRIPTION
If some AP or some mesh interface does not have anyone connected, skip it.
Otherwise `test_node` is empty and the `grep $test_node` fails.

https://github.com/nicopace/cotonete/blob/aad5bad40bc201e8a761f9ae420c10fe63237b70/packages/cotonete/files/usr/sbin/cotonete.sh#L69
